### PR TITLE
docs(hosting): add the Entry tasks page

### DIFF
--- a/docs/hosting/entry-tasks.md
+++ b/docs/hosting/entry-tasks.md
@@ -1,0 +1,67 @@
+---
+sidebar_position: 32
+---
+
+# Entry tasks
+
+Entry tasks let you ask players to do something for your community before they can register for your tournament — follow your X account, join your Discord server, join your Telegram group, or visit a link you choose.
+
+They're optional. A tournament with no entry tasks registers exactly the way it always has.
+
+## Why use them
+
+If you're running a tournament to grow a community, the tournament is the draw and the tasks are what the draw is for. Someone who wants a seat joins your Discord on the way in, and stays after the tournament ends.
+
+Used lightly, that's a fair trade. Used heavily, it's a wall — every task is one more reason for someone to give up and play elsewhere. Most tournaments do well with two or three.
+
+## Adding tasks
+
+Open your tournament page and pick the **Entry tasks** tab. It's there for every tournament you host.
+
+Choose a task type, paste the link, and give it a label players will understand ("Join the Raiku Discord" beats "Discord"). If you've already saved your community links on the tournament, they're offered as one-tap suggestions.
+
+You can add up to **six tasks** per tournament.
+
+Tasks can be changed while registration is open. Two things to know:
+
+- **Changes only affect players who haven't registered yet.** Anyone already in keeps their seat, and re-entries are never blocked by a task added after they joined.
+- **Changing a task's link resets it.** Players who already did the old version will be asked to do the new one, because it isn't the same task any more. Renaming a task's label is safe and keeps everyone's progress.
+
+## What we check, and what we don't
+
+We're straightforward with players about this, and you should know it too:
+
+| Task | What happens |
+|---|---|
+| **Join a Discord server** | Genuinely checked. The player connects their Discord account to Stacked, joins your server, and presses Verify. We confirm they're actually a member. |
+| **Follow on X** | Not checked. The player needs an X account connected to Stacked, and the task completes when they open your profile. |
+| **Join a Telegram group** | Not checked. The task completes when they open your link. |
+| **Visit a link** | Not checked. The task completes when they open it. |
+
+Only Discord is verified, so only Discord tasks are labelled that way in the app. The others are taken on trust — a player who opens the link and doesn't follow you will still get in.
+
+If that matters to you, lead with the Discord task.
+
+## Seeing how it's going
+
+The Entry tasks tab shows how many players finished each task, and a summary at the top: how many started the checklist, how many finished all of it, and how many went on to register.
+
+That last number is the one worth watching. If plenty of players start and few register, your checklist is probably too long.
+
+Per-task counts include players who finished a task but haven't registered yet, so they'll usually run ahead of your entry count.
+
+To see exactly what players are asked to do, use **Preview player checklist**.
+
+## What players see
+
+When a player presses Register on your tournament, they get the checklist. Each task has a **Go** button that opens your link; Discord tasks also have a **Verify** button.
+
+Players can also do the tasks ahead of time — the checklist is on your tournament page from the moment it's published, including before registration opens. Players who clear it early just register normally when the time comes.
+
+Registration unlocks once everything is done. Nothing else about registering changes: the buy-in, late registration and re-entries all work exactly as they normally do.
+
+You're exempt from your own checklist — you can't follow your own X account, so we don't ask you to.
+
+## Free Play
+
+Entry tasks work the same way on Free Play tournaments. Free Play chips have no cash value and Hosts earn nothing from those tournaments, but if you're using one to grow a community, the tasks do the same job.


### PR DESCRIPTION
Adds a host-facing **Entry tasks** page under Hosting, for the feature shipping in Stacked-Labs/poker-server#475 + Stacked-Labs/poker-game#710.

Hosts can ask players to follow their X, join their Discord or Telegram, or visit a link before registering for their tournament.

### What the page covers

- **Why use them**, with a plain warning that every task is another reason to give up — most tournaments want two or three, not six
- **Adding tasks**, the six-task cap, and the two edit rules that surprise people: changes never affect players who already registered, and changing a task's *link* resets it while renaming its *label* is safe
- **What we actually check** — a table making it explicit that only Discord membership is verified and the rest complete on click. A host choosing between task types should know which one carries weight
- **Reading the funnel** — started / finished-all / registered, and why per-task counts run ahead of entries
- **What players see**, including that the checklist is reachable before registration opens
- **Free Play** — same mechanics, no earnings, no blurring with real money

### Style

No vendor names, no backend mechanism, outcomes over implementation, "platform fee" never "rake", and Free Play kept distinct throughout. Sidebar position 32, after Earnings; the sidebar is autogenerated so no config change is needed.

> Note: this branch contains **only** the new page. There were uncommitted edits to `docs/about/security.md` and `docs/your-money/custody.md` in the working tree when I branched — those are untouched and still local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wvi9j6UjL6STjNwyTekS7x
